### PR TITLE
Fix windows build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,11 +37,14 @@ endif
 
 libserialport_la_LIBADD = $(LIBOBJS)
 
+libserialport_la_LDFLAGS = $(SP_LIB_LDFLAGS)
+
 if WIN32
 libserialport_la_LIBADD += -lsetupapi
+
+libserialport_la_LDFLAGS += -no-undefined
 endif
 
-libserialport_la_LDFLAGS = $(SP_LIB_LDFLAGS) -no-undefined
 
 library_includedir = $(includedir)
 library_include_HEADERS = libserialport.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ if MACOSX
 libserialport_la_SOURCES += macosx.c
 endif
 
-libserialport_la_LIBADD = $(LIBOBJS)
+libserialport_la_LIBADD = $(LIBOBJS) -lsetupapi
 
 libserialport_la_LDFLAGS = $(SP_LIB_LDFLAGS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ endif
 
 libserialport_la_LIBADD = $(LIBOBJS) -lsetupapi
 
-libserialport_la_LDFLAGS = $(SP_LIB_LDFLAGS)
+libserialport_la_LDFLAGS = $(SP_LIB_LDFLAGS) -no-undefined
 
 library_includedir = $(includedir)
 library_include_HEADERS = libserialport.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,11 @@ if MACOSX
 libserialport_la_SOURCES += macosx.c
 endif
 
-libserialport_la_LIBADD = $(LIBOBJS) -lsetupapi
+libserialport_la_LIBADD = $(LIBOBJS)
+
+if WIN32
+libserialport_la_LIBADD += -lsetupapi
+endif
 
 libserialport_la_LDFLAGS = $(SP_LIB_LDFLAGS) -no-undefined
 

--- a/libserialport_internal.h
+++ b/libserialport_internal.h
@@ -33,11 +33,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 #ifdef _WIN32
+#include <initguid.h>
+
 #include <windows.h>
 #include <tchar.h>
 #include <setupapi.h>
 #include <cfgmgr32.h>
 #include <usbioctl.h>
+#include <usbiodef.h>
 #else
 #include <limits.h>
 #include <termios.h>

--- a/windows.c
+++ b/windows.c
@@ -18,6 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <windows.h>
+#include <initguid.h>
+#include <usbiodef.h>
+
 #include "libserialport.h"
 #include "libserialport_internal.h"
 

--- a/windows.c
+++ b/windows.c
@@ -515,7 +515,7 @@ SP_PRIV enum sp_return list_ports(struct sp_port ***list)
 		strcpy(name, data);
 #endif
 		if (type == REG_SZ) {
-			DEBUG("Found port %s", name);
+			DEBUG_FMT("Found port %s", name);
 			if (!(*list = list_append(*list, name))) {
 				SET_ERROR(ret, SP_ERR_MEM, "list append failed");
 				goto out;

--- a/windows.c
+++ b/windows.c
@@ -18,8 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <initguid.h>
-
 #include "libserialport.h"
 #include "libserialport_internal.h"
 

--- a/windows.c
+++ b/windows.c
@@ -18,9 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <windows.h>
 #include <initguid.h>
-#include <usbiodef.h>
 
 #include "libserialport.h"
 #include "libserialport_internal.h"


### PR DESCRIPTION
When building for Windows (using MingW on Linux), the build fails for three reasons:

* First, the debug macro was incorrect; DEBUG_FMT() allows printf-style but DEBUG() does not.  Compiler complained and refused to build.
* Second, the UUID value was "undefined" to the linker, and refusing to generate a DLL as a result. Once the correct UUID headers were included from the Windows APIs, the build succeeded and the DLL was created.
* Third, APIs from setupapi.dll are used, but weren't linked.  The -lsetupapi command line flag has been added to fix this.
* Lastly, for some reason I do not quite understand, the mingw toolchain is not making the DLL without the `-no-undefined` command-line flag being passed to it. Doesn't make much sense to me, since there are no unresolved symbols, but now the DLL builds with a normal "./configure && make" and no extra settings.

These commits allow the mingw-compiled Windows build to work again.