### PR TITLE
fix OSX port listing on ElCapitan

### DIFF
--- a/macosx.c
+++ b/macosx.c
@@ -64,6 +64,17 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 
 		IORegistryEntryGetParentEntry(ioport, kIOServicePlane, &ioparent);
 		if ((cf_property=IORegistryEntrySearchCFProperty(ioparent,kIOServicePlane,
+		           CFSTR("IOClass"), kCFAllocatorDefault,
+		           kIORegistryIterateRecursively | kIORegistryIterateParents))) {
+			if (CFStringGetCString(cf_property, class, sizeof(class),
+			                       kCFStringEncodingASCII) &&
+			    strstr(class, "USB")) {
+				DEBUG("Found USB class device");
+				port->transport = SP_TRANSPORT_USB;
+			}
+			CFRelease(cf_property);
+		}
+		if ((cf_property=IORegistryEntrySearchCFProperty(ioparent,kIOServicePlane,
 		           CFSTR("IOProviderClass"), kCFAllocatorDefault,
 		           kIORegistryIterateRecursively | kIORegistryIterateParents))) {
 			if (CFStringGetCString(cf_property, class, sizeof(class),

--- a/serialport.c
+++ b/serialport.c
@@ -389,12 +389,12 @@ SP_API void sp_free_port_list(struct sp_port **list)
 #ifdef _WIN32
 #define CHECK_PORT_HANDLE() do { \
 	if (port->hdl == INVALID_HANDLE_VALUE) \
-		RETURN_ERROR(SP_ERR_ARG, "Invalid port handle"); \
+		RETURN_ERROR(SP_ERR_ARG, "Port not open"); \
 } while (0)
 #else
 #define CHECK_PORT_HANDLE() do { \
 	if (port->fd < 0) \
-		RETURN_ERROR(SP_ERR_ARG, "Invalid port fd"); \
+		RETURN_ERROR(SP_ERR_ARG, "Port not open"); \
 } while (0)
 #endif
 #define CHECK_OPEN_PORT() do { \


### PR DESCRIPTION
On OSX 10.11 (ElCapitan) the query for `IOProviderClass` fails to list ACM devices as USB. 
Add a fallback query using `IOClass` to correctly recognize these devices.
The fix has no effect on previous OSX versions (tested on Mavericks)