### PR TITLE
fix iSerial on windows for composite devices

### DIFF
--- a/serialport.c
+++ b/serialport.c
@@ -389,12 +389,12 @@ SP_API void sp_free_port_list(struct sp_port **list)
 #ifdef _WIN32
 #define CHECK_PORT_HANDLE() do { \
 	if (port->hdl == INVALID_HANDLE_VALUE) \
-		RETURN_ERROR(SP_ERR_ARG, "Invalid port handle"); \
+		RETURN_ERROR(SP_ERR_ARG, "Port not open"); \
 } while (0)
 #else
 #define CHECK_PORT_HANDLE() do { \
 	if (port->fd < 0) \
-		RETURN_ERROR(SP_ERR_ARG, "Invalid port fd"); \
+		RETURN_ERROR(SP_ERR_ARG, "Port not open"); \
 } while (0)
 #endif
 #define CHECK_OPEN_PORT() do { \


### PR DESCRIPTION
USB composite devices can contain an ACM serial interface. 
On Windows, the correct iSerial descriptor field is assigned to the parent (composite) device instead than to the actual serial interface. A bogus value is returned if the serial interface is asked to provide the S/N.
This patch provides a fallback for this kind of devices (tested on Android with adb + cdc gadgets and on Arduino Zero Programming Port)