### PR TITLE
Fix sp_nonblocking_write writing only one byte, and fails.

### DIFF
--- a/libserialport_internal.h
+++ b/libserialport_internal.h
@@ -107,8 +107,6 @@ struct sp_port {
 	OVERLAPPED read_ovl;
 	OVERLAPPED wait_ovl;
 	DWORD events;
-	BYTE pending_byte;
-	BOOL writing;
 	BOOL wait_running;
 #else
 	int fd;


### PR DESCRIPTION
This is a reimplementation of **sp_nonblocking_write** with minor changes, where it only writes one byte to the serial port and returns.
This reimplementation drops the use of the **HasOverlappedIoCompleted** macro and replace it with **GetOverlappedResult** which is the best choice according to the MSDN documentation.

> **GetOverlappedResult**
bWait [in]
If this parameter is TRUE, and the Internal member of the lpOverlapped structure is STATUS_PENDING, the function does not return until the operation has been completed. If this parameter is FALSE and the operation is still pending, the function returns FALSE and the GetLastError function returns ERROR_IO_INCOMPLETE.

> **HasOverlappedIoCompleted**
Remarks
Do not call this macro unless the call to GetLastError returns ERROR_IO_PENDING, indicating that the overlapped I/O has started.

and also instead of doing a loop for a byte-by-byte nonblocking write which is causing the failiure of the function, a bulk write according to the requested count number of bytes is done once.