### PR TITLE
Symlink b

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,10 @@ AC_CHECK_TYPES([struct serial_struct],,, [[#include <linux/serial.h>]])
 # Check for realpath().
 AC_CHECK_FUNC([realpath], [AC_DEFINE(HAVE_REALPATH, 1, [realpath is available.])], [])
 
+# Check for flock().
+AC_CHECK_HEADER([sys/file.h], [AC_DEFINE(HAVE_SYS_FILE_H, 1, [sys/file.h is available.])], [])
+AC_CHECK_FUNC([flock], [AC_DEFINE(HAVE_FLOCK, 1, [flock is available.])], [])
+
 # Check for clock_gettime().
 AC_CHECK_FUNC([clock_gettime],
 	[AC_DEFINE(HAVE_CLOCK_GETTIME, 1, [clock_gettime is available.])], [])

--- a/examples/send_receive.c
+++ b/examples/send_receive.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 		/* Try to receive the data on the other port. */
 		printf("Receiving %d bytes on port %s.\n",
 				size, sp_get_port_name(rx_port));
-		check(sp_blocking_read(rx_port, buf, size, timeout));
+		result = check(sp_blocking_read(rx_port, buf, size, timeout));
 
 		/* Check whether we received the number of bytes we wanted. */
 		if (result == size)

--- a/libserialport_internal.h
+++ b/libserialport_internal.h
@@ -82,6 +82,9 @@
 #include <time.h>
 #include <poll.h>
 #include <unistd.h>
+#ifdef HAVE_SYS_FILE_H
+#include <sys/file.h>
+#endif
 #endif
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>

--- a/linux.c
+++ b/linux.c
@@ -40,6 +40,7 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 	 * Description limited to 127 char, anything longer
 	 * would not be user friendly anyway.
 	 */
+	char name[PATH_MAX + 1];
 	char description[128];
 	int bus, address;
 	unsigned int vid, pid;
@@ -47,12 +48,17 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 	char baddr[32];
 	const char dir_name[] = "/sys/class/tty/%s/device/%s%s";
 	char sub_dir[32] = "", link_name[PATH_MAX], file_name[PATH_MAX];
-	char *ptr, *dev = port->name + 5;
+	char *ptr, *dev;
 	FILE *file;
 	int i, count;
 	struct stat statbuf;
 
-	if (strncmp(port->name, "/dev/", 5))
+	char *res = realpath(port->name, name);
+	if (!res)
+		RETURN_ERROR(SP_ERR_ARG, "Could not retrieve realpath behind port name");
+	dev = name + 5;
+
+	if (strncmp(name, "/dev/", 5))
 		RETURN_ERROR(SP_ERR_ARG, "Device name not recognized");
 
 	snprintf(link_name, sizeof(link_name), "/sys/class/tty/%s", dev);

--- a/serialport.c
+++ b/serialport.c
@@ -155,10 +155,7 @@ SP_API enum sp_transport sp_get_port_transport(const struct sp_port *port)
 {
 	TRACE("%p", port);
 
-	if (!port)
-		RETURN_ERROR(SP_ERR_ARG, "Null port");
-
-	RETURN_INT(port->transport);
+	RETURN_INT(port ? port->transport : SP_TRANSPORT_NATIVE);
 }
 
 SP_API enum sp_return sp_get_port_usb_bus_address(const struct sp_port *port,

--- a/serialport.c
+++ b/serialport.c
@@ -73,20 +73,6 @@ SP_API enum sp_return sp_get_port_by_name(const char *portname, struct sp_port *
 
 	DEBUG_FMT("Building structure for port %s", portname);
 
-#if !defined(_WIN32) && defined(HAVE_REALPATH)
-	/*
-	 * get_port_details() below tries to be too smart and figure out
-	 * some transport properties from the port name which breaks with
-	 * symlinks. Therefore we canonicalize the portname first.
-	 */
-	char pathbuf[PATH_MAX + 1];
-	char *res = realpath(portname, pathbuf);
-	if (!res)
-		RETURN_ERROR(SP_ERR_ARG, "Could not retrieve realpath behind port name");
-
-	portname = pathbuf;
-#endif
-
 	if (!(port = malloc(sizeof(struct sp_port))))
 		RETURN_ERROR(SP_ERR_MEM, "Port structure malloc failed");
 

--- a/serialport.c
+++ b/serialport.c
@@ -633,7 +633,8 @@ SP_API enum sp_return sp_open(struct sp_port *port, enum sp_mode flags)
 	data.term.c_cc[VTIME] = 0;
 
 	/* Ignore modem status lines; enable receiver; leave control lines alone on close. */
-	data.term.c_cflag |= (CLOCAL | CREAD | HUPCL);
+	data.term.c_cflag |= (CLOCAL | CREAD);
+	data.term.c_cflag &= ~(HUPCL);
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
I submitted a pull request on the official sigrok repo with this same change but it seems like your repo gets a bit more action. So I though I would post a PR here as well. I am new to this so let me know if there are any issues with what I have done.

I like to add the ability for libserialport to recognize and use symlinks on Linux. This is primarily in support of the Arduino IDE which uses libserialport to enumerate and list serial ports however it seems like it would be beneficial to any libserialport users. Symlinks are created on Linux when udev rules are used to map a specific device or class of devices to a symlink. In order to accommodate this I have added code to find symlinks base on TTY devices found and then I removed a block of code that ensure a real path was passed to the serial port creator and moved this call in the Linux only portion of the code. Based on some research Mac OSX doesn't seem allow for symlink serial ports and there was a guard on the code already to stop it from running on Windows so that leaves BSD which I am unfamiliar with. I am sure BSD allows for symlinks but it doesn't look like it uses the same path searching method to determine port characteristics so I though moving that bit of code would be safe. I have another version of this feature where I added a realpath element to the sp_port struct. This would leave that realpath block in place but assign that real path to the struct there however that seemed more error prone. I was able to get all of the examples to run with my code modifications.

The only other note is that there is two commits here the first adds the code to allow the symlinks to be found. The second moves the realpath code to allow the symlink port names to pass through.